### PR TITLE
Extended python support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@
 
 language: python
 python:
-  - "3.6"
   - "3.7"
   - "3.8"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@
 
 language: python
 python:
+  - "3.6"
+  - "3.7"
   - "3.8"
 
 install:

--- a/codeflare/_version.py
+++ b/codeflare/_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = '0.1.1.dev0'
+__version__ = '0.1.2.dev0'

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author='CodeFlare team',
     author_email='chcost@us.ibm.com',
     description='Codeflare pipelines',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     keywords=("ray pipelines"),
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     author='CodeFlare team',
     author_email='chcost@us.ibm.com',
     description='Codeflare pipelines',
-    python_requires='>=3.8',
+    python_requires='>=3.6',
     keywords=("ray pipelines"),
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
**Related Issue**

CI/CD pipeline not testing for earlier Python versions now supported.

Supports #ISSUE_NUMBER

**Related PRs**

No related PRs.

This PR is not dependent on any other PR

**What does this PR do?**

This change adds Python 3.7 to the testing pipeline.

**Description of Changes**

This change adds Python 3.7 to the testing pipeline.

**What gif most accurately describes how I feel towards this PR?**

https://www.google.com/search?q=python+gifs&client=safari&rls=en&sxsrf=ALeKk01r07Lhg-7hZwO4bHzXkCXNtAOf5A:1625860261703&source=lnms&tbm=isch&sa=X&ved=2ahUKEwj2pOm64dbxAhXmRt8KHZq-CxkQ_AUoAXoECAEQAw&biw=1807&bih=1515#imgrc=tdIkPT5-mAw2nM